### PR TITLE
Remove unnecessary lexical-binding var

### DIFF
--- a/org-repo-todo.el
+++ b/org-repo-todo.el
@@ -1,4 +1,4 @@
-;;; org-repo-todo.el --- Simple repository todo management with org-mode  -*- lexical-binding: t; -*-
+;;; org-repo-todo.el --- Simple repository todo management with org-mode
 
 ;; Copyright (C) 2014  justin talbott
 


### PR DESCRIPTION
While this is added by default by `auto-insert-mode`, the var implies that the code only works with Emacs 24+ (in which case the package should depend on Emacs 24), but this doesn't appear to be the case here.
