### PR TITLE
Remove needless library loading

### DIFF
--- a/org-repo-todo.el
+++ b/org-repo-todo.el
@@ -39,7 +39,6 @@
 
 ;;; Code:
 
-(require 'cl)
 (require 'org-capture)
 
 (defvar ort/todo-root)


### PR DESCRIPTION
This package does not use cl.el functions/macros and loading cl.el at runtime causes byte-compile warning as below.

```
org-repo-todo.el:42:1:Warning: cl package required at runtime
```
